### PR TITLE
Use extras in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py{35,36,37,38,39,310}
 
 [testenv]
 commands = pytest
-deps =
-    .[tests]
+extras = tests
 passenv =
     STACK_DATA_SLOW_TESTS


### PR DESCRIPTION
`extras` is more readable than `.[tests]`