### PR TITLE
Adding skip_blank option

### DIFF
--- a/stack_data/core.py
+++ b/stack_data/core.py
@@ -336,6 +336,8 @@ class Line(object):
                     return None
         else:
             range_end = len(self.text)
+        if range_start == range_end == 0:
+            return None
 
         return RangeInLine(range_start, range_end, data)
 


### PR DESCRIPTION
I've done a first implementation of `skip_blank` option. I chose this name instead of `no_skip_blank` that I had mentioned before since it seemed more natural to use a name that corresponded to the default.

Here's an example, first showing the default result:
```
Traceback (most recent call last):
 File "C:\Users\Andre\github\stack_data\example.py", line 8, in <module>
       1 | import stack_data
       3 | stack_data.Formatter().set_hook()
       5 | word = "word"
-->    8 | nb_ = len(letter
                 ^^^^^^^^^^
       9 |             for letter
                       ^^^^^^^^^^
      10 |               in
                       ^^^^
      11 |             word)
                       ^^^^^
      13 | pass
TypeError: object of type 'generator' has no len()
```
Next, with this new option enabled, by setting `skip_blank=False`:
```
Traceback (most recent call last):
 File "C:\Users\Andre\github\stack_data\example.py", line 8, in <module>
       1 | import stack_data
       2 |
       3 | stack_data.Formatter(skip_blank=False).set_hook()
       4 |
       5 | word = "word"
       : |
-->    8 | nb_ = len(letter
                 ^^^^^^^^^^
       9 |             for letter
                       ^^^^^^^^^^
      10 |               in
                       ^^^^
      11 |             word)
                       ^^^^^
      12 |
      13 | pass
TypeError: object of type 'generator' has no len()
```

I have also fixed a bug with the multiline highlighting when the "executing piece" included a blank line.  Here's an example before the bug fix:
```
Traceback (most recent call last):
 File "C:\Users\Andre\github\stack_data\example.py", line 8, in <module>
       1 | import stack_data
       3 | stack_data.Formatter().set_hook()
       5 | word = "word"
-->    8 | nb_ = len(letter
                 ^^^^^^^^^^
       9 |

      10 |             for letter
           ^^^^^^^^^^^^^^^^^^^^^^
      11 |               in
           ^^^^^^^^^^^^^^^^
      12 |             word)
           ^^^^^^^^^^^^^^^^^
      14 | pass
TypeError: object of type 'generator' has no len()
```
And the result after fixing the bug:
```
Traceback (most recent call last):
 File "C:\Users\Andre\github\stack_data\example.py", line 8, in <module>
       1 | import stack_data
       3 | stack_data.Formatter().set_hook()
       5 | word = "word"
-->    8 | nb_ = len(letter
                 ^^^^^^^^^^
       9 |

      10 |             for letter
                       ^^^^^^^^^^
      11 |               in
                       ^^^^
      12 |             word)
                       ^^^^^
      14 | pass
TypeError: object of type 'generator' has no len()
```

I have not yet created unit tests.
