### PR TITLE
Implementing skip_blank option

### DIFF
--- a/stack_data/__init__.py
+++ b/stack_data/__init__.py
@@ -1,5 +1,5 @@
 from .core import Source, FrameInfo, markers_from_ranges, Options, LINE_GAP, Line, Variable, RangeInLine, \
-    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLines
+    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLineMark, BlankLines
 from .formatting import Formatter
 from .serializing import Serializer
 

--- a/stack_data/__init__.py
+++ b/stack_data/__init__.py
@@ -1,5 +1,5 @@
 from .core import Source, FrameInfo, markers_from_ranges, Options, LINE_GAP, Line, Variable, RangeInLine, \
-    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLineRange, BlankLines, EmptyLine
+    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLineRange, BlankLines
 from .formatting import Formatter
 from .serializing import Serializer
 

--- a/stack_data/__init__.py
+++ b/stack_data/__init__.py
@@ -1,5 +1,5 @@
 from .core import Source, FrameInfo, markers_from_ranges, Options, LINE_GAP, Line, Variable, RangeInLine, \
-    RepeatedFrames, MarkerInLine, style_with_executing_node
+    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLines
 from .formatting import Formatter
 from .serializing import Serializer
 

--- a/stack_data/__init__.py
+++ b/stack_data/__init__.py
@@ -1,5 +1,5 @@
 from .core import Source, FrameInfo, markers_from_ranges, Options, LINE_GAP, Line, Variable, RangeInLine, \
-    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLineMark, BlankLines, EmptyLine
+    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLineRange, BlankLines, EmptyLine
 from .formatting import Formatter
 from .serializing import Serializer
 

--- a/stack_data/__init__.py
+++ b/stack_data/__init__.py
@@ -1,5 +1,5 @@
 from .core import Source, FrameInfo, markers_from_ranges, Options, LINE_GAP, Line, Variable, RangeInLine, \
-    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLineMark, BlankLines
+    RepeatedFrames, MarkerInLine, style_with_executing_node, BlankLineMark, BlankLines, EmptyLine
 from .formatting import Formatter
 from .serializing import Serializer
 

--- a/stack_data/core.py
+++ b/stack_data/core.py
@@ -212,7 +212,7 @@ LINE_GAP = LineGap()
 
 class BlankLineRange:
     """
-    Records the line number range for blank lines gaps between executing pieces.
+    Records the line number range for blank lines gaps between pieces.
     For a single blank line, begin_lineno == end_lineno.
     """
     def __init__(self, begin_lineno: int, end_lineno: int):

--- a/stack_data/core.py
+++ b/stack_data/core.py
@@ -761,14 +761,12 @@ class FrameInfo(object):
                     and pieces[1] != self.scope_pieces[1]
             ):
                 result.append(LINE_GAP)
-            elif (prev_piece and add_empty_lines and piece.start > prev_piece.stop):
-                lines = []  # type: List[Union[EmptyLine, BlankLineRange]]
+            elif prev_piece and add_empty_lines and piece.start > prev_piece.stop:
                 if self.blank_lines == BlankLines.LINE_NUMBER:
-                    lines.append(BlankLineRange(prev_piece.stop, piece.start-1))
+                    result.append(BlankLineRange(prev_piece.stop, piece.start-1))
                 else:  # BlankLines.VISIBLE
                     for lineno in range(prev_piece.stop, piece.start):
-                        lines.append(EmptyLine(self, lineno))
-                result.extend(lines)
+                        result.append(EmptyLine(self, lineno))
 
             lines = [Line(self, i) for i in piece]  # type: List[Line]
             if piece != self.executing_piece:

--- a/stack_data/core.py
+++ b/stack_data/core.py
@@ -219,6 +219,11 @@ class BlankLineMark:
         self.end_lineno = end_lineno
 
 
+class EmptyLine:
+    def __init__(self, lineno):
+        self.lineno = lineno
+
+
 class Line(object):
     """
     A single line of source code for a particular stack frame.
@@ -766,6 +771,18 @@ class FrameInfo(object):
                     new_lines.append(BlankLineMark(prev_line.lineno+1, line.lineno-1))
                 new_lines.append(line)
             return new_lines
+
+        if self.blank_lines == BlankLines.VISIBLE:
+            new_lines = [result[0]]
+            for line in result[1:]:
+                prev_line = new_lines[-1]
+                if (isinstance(prev_line, Line) and isinstance(line, Line)
+                    and line.lineno - prev_line.lineno > 1):
+                    for lineno in range(prev_line.lineno+1, line.lineno):
+                        new_lines.append(EmptyLine(lineno))
+                new_lines.append(line)
+            return new_lines
+
 
         return result
 

--- a/stack_data/core.py
+++ b/stack_data/core.py
@@ -336,6 +336,8 @@ class Line(object):
                     return None
         else:
             range_end = len(self.text)
+        if range_start == range_end == 0:
+            return None
 
         return RangeInLine(range_start, range_end, data)
 

--- a/stack_data/core.py
+++ b/stack_data/core.py
@@ -50,7 +50,7 @@ Then use Line.render to insert the markers correctly.
 class BlankLines(Enum):
     HIDDEN = 1
     VISIBLE = 2
-    LINE_NUMBER=3
+    COLLAPSED=3
 
 class Variable(
     NamedTuple('_Variable',
@@ -566,10 +566,7 @@ class FrameInfo(object):
         self.code = frame.f_code
         self.options = options or Options()  # type: Options
         self.source = self.executing.source  # type: Source
-        if hasattr(self.options, "blank_lines"):
-            self.blank_lines = self.options.blank_lines
-        else:
-            self.blank_lines = BlankLines.HIDDEN
+
 
     def __repr__(self):
         return "{self.__class__.__name__}({self.frame})".format(self=self)
@@ -750,7 +747,7 @@ class FrameInfo(object):
         if not pieces:
             return []
 
-        add_empty_lines = self.blank_lines in (BlankLines.VISIBLE, BlankLines.LINE_NUMBER)
+        add_empty_lines = self.options.blank_lines in (BlankLines.VISIBLE, BlankLines.COLLAPSED)
         prev_piece = None
         result = []
         for i, piece in enumerate(pieces):
@@ -762,11 +759,11 @@ class FrameInfo(object):
             ):
                 result.append(LINE_GAP)
             elif prev_piece and add_empty_lines and piece.start > prev_piece.stop:
-                if self.blank_lines == BlankLines.LINE_NUMBER:
+                if self.options.blank_lines == BlankLines.COLLAPSED:
                     result.append(BlankLineRange(prev_piece.stop, piece.start-1))
                 else:  # BlankLines.VISIBLE
                     for lineno in range(prev_piece.stop, piece.start):
-                        result.append(EmptyLine(self, lineno))
+                        result.append(Line(self, lineno))
 
             lines = [Line(self, i) for i in piece]  # type: List[Line]
             if piece != self.executing_piece:

--- a/stack_data/core.py
+++ b/stack_data/core.py
@@ -219,11 +219,6 @@ class BlankLineMark:
         self.end_lineno = end_lineno
 
 
-class EmptyLine:
-    def __init__(self, lineno):
-        self.lineno = lineno
-
-
 class Line(object):
     """
     A single line of source code for a particular stack frame.
@@ -410,6 +405,27 @@ class Line(object):
             start = max(marker.position, original_start)
         return ''.join(parts)
 
+
+class EmptyLine(Line):
+    def __init__(
+            self,
+            frame_info: 'FrameInfo',
+            lineno: int,
+    ):
+        self.frame_info = frame_info
+        self.lineno = lineno
+        self.text = ''
+        # self.leading_indent = None  # type: Optional[int]
+
+    def render(
+            self,
+            markers: Iterable[MarkerInLine] = (),
+            *,
+            strip_leading_indent: bool = True,
+            pygmented: bool = False,
+            escape_html: bool = False
+    ) -> str:
+        return ''
 
 def markers_from_ranges(
         ranges: Iterable[RangeInLine],
@@ -779,7 +795,7 @@ class FrameInfo(object):
                 if (isinstance(prev_line, Line) and isinstance(line, Line)
                     and line.lineno - prev_line.lineno > 1):
                     for lineno in range(prev_line.lineno+1, line.lineno):
-                        new_lines.append(EmptyLine(lineno))
+                        new_lines.append(EmptyLine(line.frame_info, lineno))
                 new_lines.append(line)
             return new_lines
 

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -183,7 +183,6 @@ class Formatter:
         if self.show_linenos:
             result += self.line_number_format_string.format(line.lineno)
 
-        result = result or "   "
         prefix = result
 
         result += line.render(
@@ -209,7 +208,10 @@ class Formatter:
 
 
     def format_blank_lines_linenumbers(self, blank_line):
-        result = " " * len(self.current_line_indicator) + " "
+        if self.current_line_indicator:
+            result = " " * len(self.current_line_indicator) + " "
+        else:
+            result = "   "
         if blank_line.begin_lineno == blank_line.end_lineno:
             return result + self.line_number_format_string.format(blank_line.begin_lineno) + "\n"
         return result + "   {}\n".format(self.line_number_gap_string)

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -4,7 +4,8 @@ import traceback
 from types import FrameType, TracebackType
 from typing import Union, Iterable
 
-from stack_data import style_with_executing_node, Options, Line, FrameInfo, LINE_GAP, Variable, RepeatedFrames, BlankLineMark
+from stack_data import (style_with_executing_node, Options, Line, FrameInfo, LINE_GAP,
+                       Variable, RepeatedFrames, BlankLineMark, EmptyLine)
 from stack_data.utils import assert_
 
 
@@ -140,6 +141,8 @@ class Formatter:
                 yield self.format_line(line)
             elif isinstance(line, BlankLineMark) and self.show_linenos:
                 yield self.format_blank_lines(line)
+            elif isinstance(line, EmptyLine):
+                yield self.format_empty_line(line)
             else:
                 assert_(line is LINE_GAP)
                 yield self.line_gap_string + "\n"
@@ -198,11 +201,20 @@ class Formatter:
         result = ""
         if self.current_line_indicator:
             result = " " * len(self.current_line_indicator)
-        result = result or "   "
+        else:
+            result = "   "
         if blank_line.begin_lineno == blank_line.end_lineno:
             return result + " {:4} |\n".format(blank_line.begin_lineno)
         return result + "    :\n"
 
+    def format_empty_line(self, line: Line) -> str:
+        result = ""
+        if self.show_linenos:
+            if self.current_line_indicator:
+                result = " " * len(self.current_line_indicator) + " "
+            result += "{:4} | ".format(line.lineno)
+
+        return result + "\n"
 
     def format_variables(self, frame_info: FrameInfo) -> Iterable[str]:
         for var in sorted(frame_info.variables, key=lambda v: v.name):

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -4,7 +4,7 @@ import traceback
 from types import FrameType, TracebackType
 from typing import Union, Iterable
 
-from stack_data import style_with_executing_node, Options, Line, FrameInfo, LINE_GAP, Variable, RepeatedFrames, BlankLines
+from stack_data import style_with_executing_node, Options, Line, FrameInfo, LINE_GAP, Variable, RepeatedFrames, BlankLineMark
 from stack_data.utils import assert_
 
 
@@ -138,7 +138,7 @@ class Formatter:
         for line in frame.lines:
             if isinstance(line, Line):
                 yield self.format_line(line)
-            elif isinstance(line, BlankLines) and self.show_linenos:
+            elif isinstance(line, BlankLineMark) and self.show_linenos:
                 yield self.format_blank_lines(line)
             else:
                 assert_(line is LINE_GAP)
@@ -201,7 +201,7 @@ class Formatter:
         result = result or "   "
         if blank_line.begin_lineno == blank_line.end_lineno:
             return result + " {:4} |\n".format(blank_line.begin_lineno)
-        return result + "    : |\n"
+        return result + "    :\n"
 
 
     def format_variables(self, frame_info: FrameInfo) -> Iterable[str]:

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -67,9 +67,9 @@ class Formatter:
         self.chain = chain
         self.options = options
         self.collapse_repeated_frames = collapse_repeated_frames
-        if not self.show_linenos and self.options.blank_lines == BlankLines.COLLAPSED:
+        if not self.show_linenos and self.options.blank_lines == BlankLines.SINGLE:
             raise ValueError(
-                "BlankLines.COLLAPSED option can only be used when show_linenos=True"
+                "BlankLines.SINGLE option can only be used when show_linenos=True"
             )
 
     def set_hook(self):

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -27,8 +27,7 @@ class Formatter:
             strip_leading_indent=True,
             html=False,
             chain=True,
-            collapse_repeated_frames=True,
-            skip_blank = True
+            collapse_repeated_frames=True
     ):
         if options is None:
             options = Options()
@@ -65,8 +64,6 @@ class Formatter:
         self.chain = chain
         self.options = options
         self.collapse_repeated_frames = collapse_repeated_frames
-        self.skip_blank = skip_blank
-        self.last_lineno_printed = None
 
     def set_hook(self):
         def excepthook(_etype, evalue, _tb):
@@ -140,14 +137,10 @@ class Formatter:
 
         for line in frame.lines:
             if isinstance(line, Line):
-                if self.show_linenos and not self.skip_blank:
-                    yield self.perhaps_add_blank_lines(line)
-                    self.last_lineno_printed = line.lineno
                 yield self.format_line(line)
             else:
                 assert_(line is LINE_GAP)
                 yield self.line_gap_string + "\n"
-                self.last_lineno_printed = None
 
         if self.show_variables:
             try:
@@ -196,22 +189,6 @@ class Formatter:
                         + self.executing_node_underline * (end - start)
                         + "\n"
                 )
-        return result
-
-
-    def perhaps_add_blank_lines(self, line):
-        if self.last_lineno_printed is None:
-            return ""
-        gap = line.lineno - self.last_lineno_printed
-        if line.executing_node_ranges:
-             self.last_lineno_printed = None
-        if gap <= 1:
-            return ""
-        leading_space = " " * (len(self.current_line_indicator) + 1)
-        if gap == 2:
-            result = leading_space + "{:4} |\n".format(self.last_lineno_printed + 1)
-        else:
-            result = leading_space + "   : |\n"
         return result
 
 

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -67,9 +67,9 @@ class Formatter:
         self.chain = chain
         self.options = options
         self.collapse_repeated_frames = collapse_repeated_frames
-        if not self.show_linenos and self.options.blank_lines == BlankLines.LINE_NUMBER:
+        if not self.show_linenos and self.options.blank_lines == BlankLines.COLLAPSED:
             raise ValueError(
-                "BlankLines.LINE_NUMBER option can only be used when show_linenos=True"
+                "BlankLines.COLLAPSED option can only be used when show_linenos=True"
             )
 
     def set_hook(self):

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -213,7 +213,7 @@ class Formatter:
         else:
             result = "   "
         if blank_line.begin_lineno == blank_line.end_lineno:
-            return result + " {:4} |\n".format(blank_line.begin_lineno)
+            return result + " " + self.line_number_format_string.format(blank_line.begin_lineno) + "\n"
         return result + "    {}\n".format(self.line_number_gap_string)
 
 

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -23,6 +23,7 @@ class Formatter:
             current_line_indicator="-->",
             line_gap_string="(...)",
             line_number_gap_string=":",
+            line_number_format_string="{:4} | ",
             show_variables=False,
             use_code_qualname=True,
             show_linenos=True,
@@ -59,6 +60,7 @@ class Formatter:
         self.current_line_indicator = current_line_indicator or ""
         self.line_gap_string = line_gap_string
         self.line_number_gap_string = line_number_gap_string
+        self.line_number_format_string = line_number_format_string
         self.show_variables = show_variables
         self.show_linenos = show_linenos
         self.use_code_qualname = use_code_qualname
@@ -177,7 +179,7 @@ class Formatter:
             result += " "
 
         if self.show_linenos:
-            result += "{:4} | ".format(line.lineno)
+            result += self.line_number_format_string.format(line.lineno)
 
         result = result or "   "
 

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -177,10 +177,13 @@ class Formatter:
             else:
                 result = " " * len(self.current_line_indicator)
             result += " "
+        else:
+            result = "   "
 
         if self.show_linenos:
             result += self.line_number_format_string.format(line.lineno)
 
+        result = result or "   "
         prefix = result
 
         result += line.render(

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -141,8 +141,6 @@ class Formatter:
                 yield self.format_line(line)
             elif isinstance(line, BlankLineMark) and self.show_linenos:
                 yield self.format_blank_lines(line)
-            elif isinstance(line, EmptyLine):
-                yield self.format_empty_line(line)
             else:
                 assert_(line is LINE_GAP)
                 yield self.line_gap_string + "\n"
@@ -207,14 +205,6 @@ class Formatter:
             return result + " {:4} |\n".format(blank_line.begin_lineno)
         return result + "    :\n"
 
-    def format_empty_line(self, line: Line) -> str:
-        result = ""
-        if self.show_linenos:
-            if self.current_line_indicator:
-                result = " " * len(self.current_line_indicator) + " "
-            result += "{:4} | ".format(line.lineno)
-
-        return result + "\n"
 
     def format_variables(self, frame_info: FrameInfo) -> Iterable[str]:
         for var in sorted(frame_info.variables, key=lambda v: v.name):

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -4,7 +4,7 @@ import traceback
 from types import FrameType, TracebackType
 from typing import Union, Iterable
 
-from stack_data import style_with_executing_node, Options, Line, FrameInfo, LINE_GAP, Variable, RepeatedFrames
+from stack_data import style_with_executing_node, Options, Line, FrameInfo, LINE_GAP, Variable, RepeatedFrames, BlankLines
 from stack_data.utils import assert_
 
 
@@ -138,6 +138,8 @@ class Formatter:
         for line in frame.lines:
             if isinstance(line, Line):
                 yield self.format_line(line)
+            elif isinstance(line, BlankLines) and self.show_linenos:
+                yield self.format_blank_lines(line)
             else:
                 assert_(line is LINE_GAP)
                 yield self.line_gap_string + "\n"
@@ -190,6 +192,16 @@ class Formatter:
                         + "\n"
                 )
         return result
+
+
+    def format_blank_lines(self, blank_line):
+        result = ""
+        if self.current_line_indicator:
+            result = " " * len(self.current_line_indicator)
+        result = result or "   "
+        if blank_line.begin_lineno == blank_line.end_lineno:
+            return result + " {:4} |\n".format(blank_line.begin_lineno)
+        return result + "    : |\n"
 
 
     def format_variables(self, frame_info: FrameInfo) -> Iterable[str]:

--- a/stack_data/formatting.py
+++ b/stack_data/formatting.py
@@ -181,8 +181,6 @@ class Formatter:
         if self.show_linenos:
             result += self.line_number_format_string.format(line.lineno)
 
-        result = result or "   "
-
         prefix = result
 
         result += line.render(
@@ -208,13 +206,10 @@ class Formatter:
 
 
     def format_blank_lines_linenumbers(self, blank_line):
-        if self.current_line_indicator:
-            result = " " * len(self.current_line_indicator)
-        else:
-            result = "   "
+        result = " " * len(self.current_line_indicator) + " "
         if blank_line.begin_lineno == blank_line.end_lineno:
-            return result + " " + self.line_number_format_string.format(blank_line.begin_lineno) + "\n"
-        return result + "    {}\n".format(self.line_number_gap_string)
+            return result + self.line_number_format_string.format(blank_line.begin_lineno) + "\n"
+        return result + "   {}\n".format(self.line_number_gap_string)
 
 
     def format_variables(self, frame_info: FrameInfo) -> Iterable[str]:

--- a/tests/golden_files/blank_invisible_no_linenos.txt
+++ b/tests/golden_files/blank_invisible_no_linenos.txt
@@ -1,8 +1,8 @@
 Traceback (most recent call last):
  File "formatter_example.py", line 85, in blank_lines
-    def blank_lines():
-        a = [1, 2, 3]
-        length = len(a)
--->     return a[length]
-               ^^^^^^^^^
+   def blank_lines():
+       a = [1, 2, 3]
+       length = len(a)
+       return a[length]
+              ^^^^^^^^^
 IndexError: list index out of range

--- a/tests/golden_files/blank_invisible_no_linenos.txt
+++ b/tests/golden_files/blank_invisible_no_linenos.txt
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+ File "formatter_example.py", line 85, in blank_lines
+    def blank_lines():
+        a = [1, 2, 3]
+        length = len(a)
+-->     return a[length]
+               ^^^^^^^^^
+IndexError: list index out of range

--- a/tests/golden_files/blank_single.txt
+++ b/tests/golden_files/blank_single.txt
@@ -2,7 +2,7 @@ Traceback (most recent call last):
  File "formatter_example.py", line 85, in blank_lines
       79 | def blank_lines():
       80 |     a = [1, 2, 3]
-      81 |
+      81 | 
       82 |     length = len(a)
        :
 -->   85 |     return a[length]

--- a/tests/golden_files/blank_single.txt
+++ b/tests/golden_files/blank_single.txt
@@ -1,0 +1,10 @@
+Traceback (most recent call last):
+ File "formatter_example.py", line 85, in blank_lines
+      79 | def blank_lines():
+      80 |     a = [1, 2, 3]
+      81 |
+      82 |     length = len(a)
+       :
+-->   85 |     return a[length]
+                      ^^^^^^^^^
+IndexError: list index out of range

--- a/tests/golden_files/blank_visible.txt
+++ b/tests/golden_files/blank_visible.txt
@@ -1,0 +1,11 @@
+Traceback (most recent call last):
+ File "formatter_example.py", line 85, in blank_lines
+      79 | def blank_lines():
+      80 |     a = [1, 2, 3]
+      81 | 
+      82 |     length = len(a)
+      83 | 
+      84 | 
+-->   85 |     return a[length]
+                      ^^^^^^^^^
+IndexError: list index out of range

--- a/tests/golden_files/blank_visible_no_linenos.txt
+++ b/tests/golden_files/blank_visible_no_linenos.txt
@@ -1,0 +1,11 @@
+Traceback (most recent call last):
+ File "formatter_example.py", line 85, in blank_lines
+    def blank_lines():
+        a = [1, 2, 3]
+    
+        length = len(a)
+    
+    
+-->     return a[length]
+               ^^^^^^^^^
+IndexError: list index out of range

--- a/tests/golden_files/blank_visible_no_linenos.txt
+++ b/tests/golden_files/blank_visible_no_linenos.txt
@@ -1,11 +1,11 @@
 Traceback (most recent call last):
  File "formatter_example.py", line 85, in blank_lines
-    def blank_lines():
-        a = [1, 2, 3]
-    
-        length = len(a)
-    
-    
--->     return a[length]
-               ^^^^^^^^^
+   def blank_lines():
+       a = [1, 2, 3]
+   
+       length = len(a)
+   
+   
+       return a[length]
+              ^^^^^^^^^
 IndexError: list index out of range

--- a/tests/golden_files/blank_visible_with_linenos_no_current_line_indicator.txt
+++ b/tests/golden_files/blank_visible_with_linenos_no_current_line_indicator.txt
@@ -1,0 +1,11 @@
+Traceback (most recent call last):
+ File "formatter_example.py", line 85, in blank_lines
+     79 | def blank_lines():
+     80 |     a = [1, 2, 3]
+     81 | 
+     82 |     length = len(a)
+     83 | 
+     84 | 
+     85 |     return a[length]
+                     ^^^^^^^^^
+IndexError: list index out of range

--- a/tests/golden_files/block_left_new.txt
+++ b/tests/golden_files/block_left_new.txt
@@ -5,8 +5,9 @@ Traceback (most recent call last):
                                ^^^^^^^^^^
       73 |              for letter
                         ^^^^^^^^^^
-      74 |                in
+      74 | 
+      75 |                in
                         ^^^^
-      75 |              "words")
+      76 |              "words")
                         ^^^^^^^^
 TypeError: object of type 'generator' has no len()

--- a/tests/golden_files/block_left_old.txt
+++ b/tests/golden_files/block_left_old.txt
@@ -1,12 +1,13 @@
 Traceback (most recent call last):
- File "formatter_example.py", line 75, in block_left
+ File "formatter_example.py", line 76, in block_left
       71 | def block_left():
       72 |     nb_characters = len(letter
                                ^^^^^^^^^^
       73 |              for letter
                         ^^^^^^^^^^
-      74 |                in
+      74 | 
+      75 |                in
                         ^^^^
--->   75 |              "words")
+-->   76 |              "words")
                         ^^^^^^^^
 TypeError: object of type 'generator' has no len()

--- a/tests/golden_files/linenos_no_current_line_indicator.txt
+++ b/tests/golden_files/linenos_no_current_line_indicator.txt
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+ File "formatter_example.py", line 85, in blank_lines
+     79 | def blank_lines():
+     80 |     a = [1, 2, 3]
+     82 |     length = len(a)
+     85 |     return a[length]
+                     ^^^^^^^^^
+IndexError: list index out of range

--- a/tests/golden_files/single_option_linenos_no_current_line_indicator.txt
+++ b/tests/golden_files/single_option_linenos_no_current_line_indicator.txt
@@ -1,0 +1,10 @@
+Traceback (most recent call last):
+ File "formatter_example.py", line 85, in blank_lines
+     79 | def blank_lines():
+     80 |     a = [1, 2, 3]
+     81 | 
+     82 |     length = len(a)
+      :
+     85 |     return a[length]
+                     ^^^^^^^^^
+IndexError: list index out of range

--- a/tests/samples/formatter_example.py
+++ b/tests/samples/formatter_example.py
@@ -76,6 +76,16 @@ def block_left():
              "words")
 
 
+def blank_lines():
+    a = [1, 2, 3]
+
+    length = len(a)
+
+
+    return a[length]
+
+
+
 if __name__ == '__main__':
     try:
         bar()

--- a/tests/samples/formatter_example.py
+++ b/tests/samples/formatter_example.py
@@ -71,6 +71,7 @@ def block_right():
 def block_left():
     nb_characters = len(letter
              for letter
+
                in
              "words")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -207,7 +207,7 @@ def test_invalid_converter():
 def test_variables():
     options = Options(before=1, after=0)
     assert repr(options) == 'Options(after=0, before=1, include_signature=False, ' \
-                            'max_lines_per_piece=6, pygments_formatter=None)'
+                            'max_lines_per_piece=6, pygments_formatter=None, skip_blank=True)'
 
     def foo(arg, _arg2: str = None, *_args, **_kwargs):
         y = 123986

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -206,8 +206,10 @@ def test_invalid_converter():
 
 def test_variables():
     options = Options(before=1, after=0)
-    assert repr(options) == 'Options(after=0, before=1, include_signature=False, ' \
-                            'max_lines_per_piece=6, pygments_formatter=None, skip_blank=True)'
+    assert repr(options) == ('Options(after=0, before=1, ' +
+                             'blank_lines=<BlankLines.HIDDEN: 1>,' +
+                             ' include_signature=False, ' +
+                             'max_lines_per_piece=6, pygments_formatter=None)')
 
     def foo(arg, _arg2: str = None, *_args, **_kwargs):
         y = 123986

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -3,7 +3,7 @@ import re
 import sys
 from contextlib import contextmanager
 
-from stack_data import Formatter, FrameInfo
+from stack_data import Formatter, FrameInfo, Options, BlankLines
 from tests.utils import compare_to_file
 
 
@@ -27,7 +27,7 @@ class MyFormatter(BaseFormatter):
 
 
 def test_example(capsys):
-    from .samples.formatter_example import bar, print_stack1, format_stack1, format_frame, f_string
+    from .samples.formatter_example import bar, print_stack1, format_stack1, format_frame, f_string, blank_lines
 
     @contextmanager
     def check_example(name):
@@ -94,3 +94,15 @@ def test_example(capsys):
             cython_example.foo()
         except Exception:
             MyFormatter().print_exception()
+
+    with check_example("blank_visible"):
+        try:
+            blank_lines()
+        except Exception:
+            MyFormatter(options=Options(blank_lines=BlankLines.VISIBLE)).print_exception()
+
+    with check_example("blank_single"):
+        try:
+            blank_lines()
+        except Exception:
+            MyFormatter(options=Options(blank_lines=BlankLines.SINGLE)).print_exception()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -123,6 +123,25 @@ def test_example(capsys):
                         current_line_indicator="",
                         options=Options(blank_lines=BlankLines.VISIBLE)).print_exception()
 
+    with check_example("linenos_no_current_line_indicator"):
+        try:
+            blank_lines()
+        except Exception:
+            MyFormatter(current_line_indicator="").print_exception()
+
+    with check_example("blank_visible_with_linenos_no_current_line_indicator"):
+        try:
+            blank_lines()
+        except Exception:
+            MyFormatter(current_line_indicator="",
+                        options=Options(blank_lines=BlankLines.VISIBLE)).print_exception()
+
+    with check_example("single_option_linenos_no_current_line_indicator"):
+        try:
+            blank_lines()
+        except Exception:
+            MyFormatter(current_line_indicator="",
+                        options=Options(blank_lines=BlankLines.SINGLE)).print_exception()
 
 def test_invalid_single_option():
     with pytest.raises(ValueError):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -106,3 +106,19 @@ def test_example(capsys):
             blank_lines()
         except Exception:
             MyFormatter(options=Options(blank_lines=BlankLines.SINGLE)).print_exception()
+
+
+    with check_example("blank_visible_no_linenos"):
+        try:
+            blank_lines()
+        except Exception:
+            MyFormatter(show_linenos=False, options=Options(blank_lines=BlankLines.VISIBLE)).print_exception()
+
+
+def test_invalid_single_option():
+    try:
+        MyFormatter(show_linenos=False, options=Options(blank_lines=BlankLines.SINGLE))
+    except ValueError:
+        assert True
+    else:
+        assert False

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -3,6 +3,8 @@ import re
 import sys
 from contextlib import contextmanager
 
+import pytest
+
 from stack_data import Formatter, FrameInfo, Options, BlankLines
 from tests.utils import compare_to_file
 
@@ -111,19 +113,18 @@ def test_example(capsys):
         try:
             blank_lines()
         except Exception:
-            MyFormatter(show_linenos=False).print_exception()
+            MyFormatter(show_linenos=False, current_line_indicator="").print_exception()
 
     with check_example("blank_visible_no_linenos"):
         try:
             blank_lines()
         except Exception:
-            MyFormatter(show_linenos=False, options=Options(blank_lines=BlankLines.VISIBLE)).print_exception()
+            MyFormatter(show_linenos=False,
+                        current_line_indicator="",
+                        options=Options(blank_lines=BlankLines.VISIBLE)).print_exception()
 
 
 def test_invalid_single_option():
-    try:
+    with pytest.raises(ValueError):
         MyFormatter(show_linenos=False, options=Options(blank_lines=BlankLines.SINGLE))
-    except ValueError:
-        assert True
-    else:
-        assert False
+

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -107,6 +107,11 @@ def test_example(capsys):
         except Exception:
             MyFormatter(options=Options(blank_lines=BlankLines.SINGLE)).print_exception()
 
+    with check_example("blank_invisible_no_linenos"):
+        try:
+            blank_lines()
+        except Exception:
+            MyFormatter(show_linenos=False).print_exception()
 
     with check_example("blank_visible_no_linenos"):
         try:


### PR DESCRIPTION
I've implemented the `skip_blank` option by adding a new line type, and adding a new `Option`.
Here's an example where the default (skipping blank lines) is used:
```
Traceback (most recent call last):
 File "C:\Users\Andre\github\stack_data\example.py", line 13, in <module>
       7 |     length = len(seq)
       9 |     return seq[length]
      12 | seq = [1, 2, 3]
-->   13 | last = last_item(seq)
                  ^^^^^^^^^^^^^^
 File "C:\Users\Andre\github\stack_data\example.py", line 9, in last_item
       5 | def last_item(seq):
       7 |     length = len(seq)
-->    9 |     return seq[length]
                      ^^^^^^^^^^^
IndexError: list index out of range
```
And here's an example where `skip_blank` is set to `False`:
```
Traceback (most recent call last):
 File "C:\Users\Andre\github\stack_data\example.py", line 14, in <module>
       7 |     length = len(seq)
       : |
      10 |     return seq[length]
       : |
      13 | seq = [1, 2, 3]
-->   14 | last = last_item(seq)
                  ^^^^^^^^^^^^^^
 File "C:\Users\Andre\github\stack_data\example.py", line 10, in last_item
       5 | def last_item(seq):
       6 |
       7 |     length = len(seq)
       : |
-->   10 |     return seq[length]
                      ^^^^^^^^^^^
IndexError: list index out of range
```