### PR TITLE
DEP: set missing minimal requirement on pure_eval (require >=0.1.0 as the first version with a wheel)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = stack_data
 install_requires =
     executing>=1.2.0
     asttokens>=2.1.0
-    pure_eval
+    pure_eval>=0.1.0
 
 setup_requires = setuptools>=44; setuptools_scm[toml]>=3.4.3
 include_package_data = True


### PR DESCRIPTION
For context: I'm hunting down a bare minimal set of dependencies (including transitive ones) for astropy and ipython
In particular I'm trying to avoid building anything from source where possible, hence this arbitrary (yet seemingly compatible) minimal requirement I'm proposing.

xref https://github.com/ipython/ipython/pull/15054